### PR TITLE
Arreglo de modulos, números decimales e impresión de caracteres UTF-8

### DIFF
--- a/include/latino.h
+++ b/include/latino.h
@@ -67,7 +67,7 @@ THE SOFTWARE.
 /** Version de correcion de errores */
 #define LAT_VERSION_PARCHE  3
 /** Version de Latino */
-#define LAT_CURRENT_YEAR    2021
+#define LAT_CURRENT_YEAR    2024
 #define LAT_VERSION                                                            \
     "Latino " LAT_stringize(LAT_VERSION_MAYOR) "." LAT_stringize(              \
         LAT_VERSION_MENOR) "." LAT_stringize(LAT_VERSION_PARCHE)

--- a/src/latino.c
+++ b/src/latino.c
@@ -81,8 +81,12 @@ static void lat_ayuda() {
 }
 
 int main(int argc, char *argv[]) {
-    setlocale(LC_ALL, "");
-    setlocale(LC_CTYPE, "");
+    #if (defined __WIN32__) || (defined _WIN32)
+    SetConsoleCP(CP_UTF8);
+    SetConsoleOutputCP(CP_UTF8);
+    #endif
+    setlocale(LC_ALL, "C.UTF-8");
+    setlocale(LC_CTYPE, "C.UTF-8");
     /* para numeros decimales */
     // setlocale(LC_NUMERIC, "es_MX");
     // setlocale(LC_MONETARY, "es_MX");

--- a/src/latmv.c
+++ b/src/latmv.c
@@ -369,6 +369,7 @@ LATINO_API lat_mv *latC_crear_mv() {
     mv->error = NULL;
     mv->global->menu = false;
     mv->enBucle = 0;
+    mv->enClase = 0;
     mv->goto_break;
 
     // cargar librerias de latino
@@ -597,18 +598,16 @@ void latMV_set_symbol(lat_mv *mv, lat_objeto *name, lat_objeto *val) {
                        str_name);
         }
     }
-    ctx = obtener_contexto_global(mv);
-    lat_objeto *oldVal = (lat_objeto *)latO_obtener_contexto(
-        mv, ctx, latC_checar_cadena(mv, name));
-    /*
-    // FIXME: Error en clases
+    lat_objeto *global_ctx = obtener_contexto_global(mv);
+    lat_objeto *oldVal = latO_obtener_contexto(
+        mv, global_ctx, latC_checar_cadena(mv, name));
     if (oldVal != NULL) {
         if (oldVal->tipo == T_CFUN || oldVal->tipo == T_FUN) {
             latC_error(mv, "Intento de reasignar valor a la funcion '%s'",
-                       str_name);
+                    str_name);
         }
+        ctx = global_ctx;
     }
-    */
     latO_asignar_ctx(mv, ctx, str_name, val);
 }
 
@@ -699,7 +698,7 @@ static void latMV_call_function(lat_mv *mv, lat_objeto *func, lat_bytecode cur,
     }
     bool apilar = next.ins == STORE_NAME || !strcmp(fun->nombre, "incluir") ||
                   (fun->nombre != NULL && func->nombre != NULL &&
-                   !strcmp(func->nombre, fun->nombre));
+                   strcmp(func->nombre, fun->nombre));
     if (apilar) {
         apilar_contexto(mv, NULL);
         mv->ptrprevio = (mv->ptrpila);

--- a/src/latobj.c
+++ b/src/latobj.c
@@ -818,7 +818,7 @@ LATINO_API char *latC_astring(lat_mv *mv, lat_objeto *o) {
     } else if (o->tipo == T_INTEGER) {
         return entero_acadena(getEntero(o));
     } else if (o->tipo == T_CHAR) {
-        return (char)getCaracter(o);
+        return &getCaracter(o);
     } else if (o->tipo == T_STR) {
         return strdup(latC_checar_cadena(mv, o));
     } else if (o->tipo == T_LABEL) {

--- a/src/latsyslib.c
+++ b/src/latsyslib.c
@@ -87,13 +87,17 @@ buscar_os_version() { // Busca y asigna el valor del Build del sistema operativo
     // TODO: Implementar para MSYS2
 #else
     struct utsname buffer;
+    char *p = buffer.release;
 
     if (uname(&buffer) < 0) {
         perror("Failed to uname");
     }
     // os_v.osMayor = (int)strtol(buffer.version, (char **)NULL, 10);
     // os_v.osMayor = atoi(buffer.version);
-    os_v.osMayor = buffer.release;
+    // os_v.osMayor = buffer.release;
+    os_v.osMayor = strtol(p, &p, 10);
+    os_v.osMenor = strtol(++p, &p, 10);
+    os_v.osBuild = strtol(++p, &p, 10);
 #endif
 
     return os_v;

--- a/src/vs_resources/latino.rc
+++ b/src/vs_resources/latino.rc
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "Lenguaje de programacion con sintaxis en Espanol"
             VALUE "FileVersion", "1.4.3.0"
             VALUE "InternalName", "latino.exe"
-            VALUE "LegalCopyright", "Copyleft (C) 2015-2021"
+            VALUE "LegalCopyright", "Copyleft (C) 2015-2024"
             VALUE "OriginalFilename", "latino.exe"
             VALUE "ProductName", "Latino"
             VALUE "ProductVersion", "1.4.3.0"


### PR DESCRIPTION
## Problemas resueltos
### Problema regional
Existía un problema con la configuración regional del sistema, donde si el sistema usaba la coma como divisor de decimales (ej: 5,5), Latino terminaba ignorando los decimales declarados en la forma 5.5, por lo que trataba el número como un número entero.

### Impresión de caracteres no ASCII en Windows
El lenguaje no imprimía de manera correcta en consola/terminal los caracteres que no fueran ASCII, como pueden ser las vocales acentuadas.

### Creación de funciones en Windows
En Windows la propiedad "enClase" de la máquina virtual (lat_mv) no se iniciaba correctamente, por lo que provocaba un valor distinto de cero que reconocía cualquier función declarada como una clase.

### Contexto (módulos y funciones anónimas)
El lenguaje tenía problemas para trabajar con el contexto adecuado lo cual provocaba en módulos y funciones anónimas errores imposibles de evitar.

### Funciones y variables globales
Cuando se llamaba a una función que contenía variables y sub-funciones declaradas las mismas se exportaban de manera global, siendo accesibles fuera de la función llamada y provocando redefinición de variables globales.

### Versiones más recientes de gcc
En versiones más recientes de gcc las línea de código "return (char)getCaracter(o);" y "os_v.osMayor = buffer.release;" provocaban errores de compilación por lo que fueron corregidas para ser compatibles tanto con versiones antiguas como nuevas.