### PR TITLE
Sustitución de "retorno" por "regresar" y "devolver"

### DIFF
--- a/src/gnu-utilities/latino.nanorc
+++ b/src/gnu-utilities/latino.nanorc
@@ -18,7 +18,7 @@ color red "^[[:upper:]]+"
 ##################################################################
 
 # Palabras clave
-color magenta "\<(si|osi|sino|fin|romper|continuar|mientras|hacer|cuando|desde|nulo|retorno|caso|defecto|repetir|global|retornar)\>"
+color magenta "\<(si|osi|sino|fin|romper|continuar|mientras|hacer|cuando|desde|nulo|caso|defecto|repetir|global|retornar|regresar|devolver|ret)\>"
 color brightblue "funcion"
 color green "\<(verdadero|cierto|falso)\>"
 color brightmagenta "[[:space:]]+menu"

--- a/tools/parser/latlex.l
+++ b/tools/parser/latlex.l
@@ -126,7 +126,7 @@ EXP ([Ee][-+]?[0-9]+)
 "cierto"|"verdadero"                            { return VERDADERO; }
 "falso"                                         { return FALSO; }
 "nulo"                                          { return NULO; }
-"retorno"|"retornar"|"ret"                      { return RETORNO; }
+"retornar"|"regresar"|"devolver"|"ret"          { return RETORNO; }
 "elegir"                                        { return ELEGIR; }
 "caso"                                          { return CASO; }
 "otro"|"defecto"                                { return DEFECTO; }

--- a/tools/parser/latlex.l
+++ b/tools/parser/latlex.l
@@ -126,7 +126,7 @@ EXP ([Ee][-+]?[0-9]+)
 "cierto"|"verdadero"                            { return VERDADERO; }
 "falso"                                         { return FALSO; }
 "nulo"                                          { return NULO; }
-"retornar"|"regresar"|"devolver"|"ret"          { return RETORNO; }
+"retorno"|"retornar"|"regresar"|"devolver"|"ret"          { return RETORNO; }
 "elegir"                                        { return ELEGIR; }
 "caso"                                          { return CASO; }
 "otro"|"defecto"                                { return DEFECTO; }


### PR DESCRIPTION
En los manuales se indica que las formas de retornar un valor en una función se hace con `retornar`, `regresar` y `ret`.
Sin embargo, en el core están definidas las palabras `retornar`, `retorno` y `ret`.

Esta PR elimina el uso de la palabra reservada `retorno` a favor de `retornar` y `regresar`, definidos en los manuales.
También añade la palabra reservada nueva `devolver`, con el mismo propósito, usado en algunos otros países.

Actualizado junto a: https://github.com/lenguaje-latino/latino/pull/227